### PR TITLE
[feat] 비밀번호, 주민번호 암호화 저장 구현

### DIFF
--- a/smerp/build.gradle
+++ b/smerp/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/smerp/src/main/java/com/domino/smerp/common/config/EncryptConfig.java
+++ b/smerp/src/main/java/com/domino/smerp/common/config/EncryptConfig.java
@@ -1,0 +1,20 @@
+package com.domino.smerp.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+
+@Configuration
+public class EncryptConfig {
+    @Value("${encrypt.key}")
+    private String key;
+
+    @Value("${encrypt.salt}")
+    private String salt;
+
+    @Bean
+    public AesBytesEncryptor aesBytesEncryptor() throws  Exception{
+        return new AesBytesEncryptor(key, salt);
+    }
+}

--- a/smerp/src/main/java/com/domino/smerp/common/config/SecurityConfig.java
+++ b/smerp/src/main/java/com/domino/smerp/common/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.domino.smerp.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest()
+                                               .permitAll());
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/smerp/src/main/java/com/domino/smerp/common/encrypt/SsnEncryptor.java
+++ b/smerp/src/main/java/com/domino/smerp/common/encrypt/SsnEncryptor.java
@@ -1,0 +1,24 @@
+package com.domino.smerp.common.encrypt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.codec.Base64;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SsnEncryptor {
+    private final AesBytesEncryptor aesBytesEncryptor;
+
+    public String SsnEncryptor(String ssn) {
+
+        byte[] encrypt = aesBytesEncryptor.encrypt(ssn.getBytes());
+        return new String(Base64.encode(encrypt));
+    }
+
+    public String SsnDecryptor(String ssn) {
+
+        byte[] decode = Base64.decode(ssn.getBytes());
+        return new String(aesBytesEncryptor.decrypt(decode));
+    }
+}

--- a/smerp/src/main/java/com/domino/smerp/user/UserServiceImpl.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserServiceImpl.java
@@ -2,15 +2,19 @@ package com.domino.smerp.user;
 
 import com.domino.smerp.client.Client;
 import com.domino.smerp.client.ClientRepository;
+import com.domino.smerp.common.encrypt.SsnEncryptor;
 import com.domino.smerp.user.constants.UserRole;
 import com.domino.smerp.user.dto.request.CreateUserRequest;
 import com.domino.smerp.user.dto.request.UpdateUserRequest;
 import com.domino.smerp.user.dto.response.UserListResponse;
 import com.domino.smerp.user.dto.response.UserResponse;
 import java.time.LocalDate;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final ClientRepository clientRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SsnEncryptor ssnEncryptor;
 
     @Override
     @Transactional
@@ -49,9 +55,9 @@ public class UserServiceImpl implements UserService {
                         .email(request.getEmail())
                         .phone(request.getPhone())
                         .address(request.getAddress())
-                        .ssn(request.getSsn())
+                        .ssn(ssnEncryptor.SsnEncryptor(request.getSsn()))
                         .loginId(request.getLoginId())
-                        .password(request.getPassword())
+                        .password(passwordEncoder.encode(request.getPassword()))
                         .hireDate(LocalDate.parse(request.getHireDate()))
                         .fireDate(
                             request.getFireDate() != null ? LocalDate.parse(request.getFireDate())
@@ -102,7 +108,7 @@ public class UserServiceImpl implements UserService {
                            .email(user.getEmail())
                            .phone(user.getPhone())
                            .address(user.getAddress())
-                           .ssn(user.getSsn())
+                           .ssn(ssnEncryptor.SsnDecryptor(user.getSsn()))
                            .hireDate(user.getHireDate())
                            .fireDate(user.getFireDate())
                            .loginId(user.getLoginId())


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 사용자 등록시 작성한 비밀번호와 주민번호가 암호화를 거쳐 DB에 저장한다.
비밀번호 -> BCrypt 단방향 해시
주민번호 -> AES 대칭암호화
주민번호는 GET요청으로 가져올때 다시 복호화해서 정보를 본다,
## 🔀 작업한 브랜치 (Working Branch)
> feature/user/password-ssn

## #️⃣ 관련 이슈 (Issue)
- #14 

## ℹ️ 추가 설명 (Additional Info)
> 시큐리티는 의존성 추가만 하고 아직 작업하지 않은 상태