### PR TITLE
[feat] 유저 페이지네이션, 정렬 구현

### DIFF
--- a/smerp/src/main/java/com/domino/smerp/user/UserController.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserController.java
@@ -1,12 +1,15 @@
 package com.domino.smerp.user;
 
+import com.domino.smerp.common.dto.PageResponse;
 import com.domino.smerp.user.dto.request.CreateUserRequest;
 import com.domino.smerp.user.dto.request.UpdateUserRequest;
 import com.domino.smerp.user.dto.response.UserListResponse;
 import com.domino.smerp.user.dto.response.UserResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,10 +37,11 @@ public class UserController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<UserListResponse> showAllUsers(@RequestParam(required = false) String name,
-        @RequestParam(required = false) String deptTitle) {
+    public PageResponse<UserListResponse> searchUsers(@RequestParam(required = false) String name,
+        @RequestParam(required = false) String deptTitle,@PageableDefault(size = 20, sort = "userId", direction = Sort.Direction.DESC)
+        Pageable pageable) {
 
-        return userService.findAllUsers(name, deptTitle);
+        return userService.searchUsers(name, deptTitle,pageable);
     }
 
     @GetMapping("/{userId}")

--- a/smerp/src/main/java/com/domino/smerp/user/UserService.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserService.java
@@ -1,14 +1,15 @@
 package com.domino.smerp.user;
 
+import com.domino.smerp.common.dto.PageResponse;
 import com.domino.smerp.user.dto.request.CreateUserRequest;
 import com.domino.smerp.user.dto.request.UpdateUserRequest;
 import com.domino.smerp.user.dto.response.UserListResponse;
 import com.domino.smerp.user.dto.response.UserResponse;
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface UserService {
     void createUser(CreateUserRequest request);
-    List<UserListResponse> findAllUsers(String name, String deptTitle);
+    PageResponse<UserListResponse> searchUsers(String name, String deptTitle, Pageable pageable);
     void deleteUser(Long userId);
     UserResponse findUserById(Long userId);
     void updateUser(Long userId,UpdateUserRequest request);;

--- a/smerp/src/main/java/com/domino/smerp/user/UserServiceImpl.java
+++ b/smerp/src/main/java/com/domino/smerp/user/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.domino.smerp.user;
 
 import com.domino.smerp.client.Client;
 import com.domino.smerp.client.ClientRepository;
+import com.domino.smerp.common.dto.PageResponse;
 import com.domino.smerp.common.encrypt.SsnEncryptor;
 import com.domino.smerp.common.exception.CustomException;
 import com.domino.smerp.common.exception.ErrorCode;
@@ -12,9 +13,9 @@ import com.domino.smerp.user.dto.response.UserResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,10 +78,14 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<UserListResponse> findAllUsers(String name, String deptTitle) {
+    public PageResponse<UserListResponse> searchUsers(String name, String deptTitle,
+        Pageable pageable) {
 
-        BooleanExpression nameCondition = (name != null && !name.isEmpty()) ? QUser.user.name.startsWith(name) : null;
-        BooleanExpression deptCondition = (deptTitle != null && !deptTitle.isEmpty()) ? QUser.user.deptTitle.startsWith(deptTitle) : null;
+        BooleanExpression nameCondition =
+            (name != null && !name.isEmpty()) ? QUser.user.name.startsWith(name) : null;
+        BooleanExpression deptCondition =
+            (deptTitle != null && !deptTitle.isEmpty()) ? QUser.user.deptTitle.startsWith(deptTitle)
+                : null;
         BooleanExpression condition = null;
 
         if (nameCondition != null && deptCondition != null) {
@@ -91,18 +96,18 @@ public class UserServiceImpl implements UserService {
             condition = deptCondition;
         }
 
-        List<User> allUser = (condition == null)?  userRepository.findAll() : (List<User>) userRepository.findAll(condition);
+        Page<User> page = (condition == null) ? userRepository.findAll(pageable)
+            : userRepository.findAll(condition, pageable);
 
-        return allUser.stream()
-                      .map(users -> UserListResponse.builder()
-                                                    .name(users.getName())
-                                                    .email(users.getEmail())
-                                                    .address(users.getAddress())
-                                                    .phone(users.getPhone())
-                                                    .deptTitle(users.getDeptTitle())
-                                                    .role(users.getRole())
-                                                    .build())
-                      .collect(Collectors.toList());
+        Page<UserListResponse> pageUser = page.map(user -> UserListResponse.builder()
+                                                                           .name(user.getName())
+                                                                           .email(user.getEmail())
+                                                                           .phone(user.getPhone())
+                                                                           .address(user.getAddress())
+                                                                           .deptTitle(user.getDeptTitle())
+                                                                           .role(user.getRole())
+                                                                           .build());
+        return PageResponse.from(pageUser);
     }
 
     @Override
@@ -131,7 +136,7 @@ public class UserServiceImpl implements UserService {
                            .email(user.getEmail())
                            .phone(user.getPhone())
                            .address(user.getAddress())
-                           .ssn(decryptSsn.substring(0,8)+"******")
+                           .ssn(decryptSsn.substring(0, 8) + "******")
                            .hireDate(user.getHireDate())
                            .fireDate(user.getFireDate())
                            .loginId(user.getLoginId())
@@ -154,8 +159,10 @@ public class UserServiceImpl implements UserService {
                                   .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.updateUser(request);
 
-        if(request.getCompanyName()!=null) {
-            Client client = clientRepository.findByCompanyName(request.getCompanyName()).orElseThrow(() -> new CustomException(ErrorCode.CLIENT_NOT_FOUND));
+        if (request.getCompanyName() != null) {
+            Client client = clientRepository.findByCompanyName(request.getCompanyName())
+                                            .orElseThrow(() -> new CustomException(
+                                                ErrorCode.CLIENT_NOT_FOUND));
             user.updateClient(client);
         }
     }


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 유저를 검색하면 한페이지에 몇명에 유저를 보여줄지 그리고 원하는 정렬 조건으로 정렬해서 볼 수 있습니다.

## ✨ 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
> feature/user/page-sort

## #️⃣ 관련 이슈 (Issue)
- Closes #50 

## ℹ️ 추가 설명 (Additional Info)
> 빠르게 구현하기 위해 일단 쿼리레포지토리와 구현체 없이 구현했습니다.
기본 정렬은 userId 내림 차순으로 해놨습니다. 이유는 최근에 생성 시킨 유저부터 상단에 볼 수 있기 때문입니다.