### PR TITLE
[refactor] 품목 find메소드 다량 추가

### DIFF
--- a/smerp/src/main/java/com/domino/smerp/item/ItemService.java
+++ b/smerp/src/main/java/com/domino/smerp/item/ItemService.java
@@ -1,6 +1,7 @@
 package com.domino.smerp.item;
 
 import com.domino.smerp.common.dto.PageResponse;
+import com.domino.smerp.item.constants.ItemAct;
 import com.domino.smerp.item.dto.request.CreateItemRequest;
 import com.domino.smerp.item.dto.request.SearchItemRequest;
 import com.domino.smerp.item.dto.request.UpdateItemRequest;
@@ -8,6 +9,8 @@ import com.domino.smerp.item.dto.request.UpdateItemStatusRequest;
 import com.domino.smerp.item.dto.response.ItemDetailResponse;
 import com.domino.smerp.item.dto.response.ItemListResponse;
 import com.domino.smerp.item.dto.response.ItemStatusResponse;
+import java.math.BigDecimal;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface ItemService {
@@ -37,4 +40,17 @@ public interface ItemService {
   ItemStatus findItemStatusById(final Long itemStatusId);
 
   Item findItemById(final Long itemId);
+
+  List<Item> findItemByStatus(final ItemStatus itemStatus);
+
+  Item findItemByName(final String name);
+
+  Item findItemByRfid(final String rfid);
+
+  List<Item> findItemByItemAct(final ItemAct itemAct);
+
+  List<Item> findItemsBySafetyStockLessThan(final BigDecimal value);
+
+  List<Item> findItemsBySafetyStockGreaterThan(final BigDecimal value);
+
 }

--- a/smerp/src/main/java/com/domino/smerp/item/ItemServiceImpl.java
+++ b/smerp/src/main/java/com/domino/smerp/item/ItemServiceImpl.java
@@ -3,6 +3,7 @@ package com.domino.smerp.item;
 import com.domino.smerp.common.dto.PageResponse;
 import com.domino.smerp.common.exception.CustomException;
 import com.domino.smerp.common.exception.ErrorCode;
+import com.domino.smerp.item.constants.ItemAct;
 import com.domino.smerp.item.dto.request.CreateItemRequest;
 import com.domino.smerp.item.dto.request.SearchItemRequest;
 import com.domino.smerp.item.dto.request.UpdateItemRequest;
@@ -13,6 +14,7 @@ import com.domino.smerp.item.dto.response.ItemStatusResponse;
 import com.domino.smerp.item.repository.ItemRepository;
 import com.domino.smerp.item.repository.ItemStatusRepository;
 import java.math.BigDecimal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -135,6 +137,67 @@ public class ItemServiceImpl implements ItemService {
     return itemRepository.findById(itemId)
         .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
   }
+
+  // 품목 구분으로 리스트 조회
+  @Override
+  @Transactional(readOnly = true)
+  public List<Item> findItemByStatus(final ItemStatus itemStatus){
+    List<Item> items = itemRepository.findByItemStatus(itemStatus);
+    if (items.isEmpty()) {
+      throw new CustomException(ErrorCode.ITEM_STATUS_NOT_FOUND);
+    }
+    return items;
+  };
+
+  // 품목명으로 찾기
+  @Override
+  @Transactional(readOnly = true)
+  public Item findItemByName(final String name){
+    return itemRepository.findByName(name)
+        .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
+  }
+
+  // 품목 RFID로 찾기
+  @Override
+  @Transactional(readOnly = true)
+  public Item findItemByRfid(final String rfid){
+    return itemRepository.findByRfid(rfid)
+        .orElseThrow(() -> new CustomException(ErrorCode.ITEM_RFID_REQUIRED));
+  };
+
+  // 사용중/사용중지 중에 1개 고르면 해당하는 품목 리스트 리턴
+  @Override
+  @Transactional(readOnly = true)
+  public List<Item> findItemByItemAct(final ItemAct itemAct){
+    List<Item> items = itemRepository.findByItemAct(itemAct);
+    if (items.isEmpty()) {
+      throw new CustomException(ErrorCode.ITEM_STATUS_NOT_FOUND);
+    }
+    return items;
+  };
+
+  // 안전재고 수량 미만
+  @Override
+  @Transactional(readOnly = true)
+  public List<Item> findItemsBySafetyStockLessThan(final BigDecimal value) {
+    List<Item> items = itemRepository.findBySafetyStockLessThan(value);
+    if (items.isEmpty()) {
+      throw new CustomException(ErrorCode.ITEM_NOT_FOUND);
+    }
+    return items;
+  }
+  // 안전재고 수량 이상
+  @Override
+  @Transactional(readOnly = true)
+  public List<Item> findItemsBySafetyStockGreaterThan(final BigDecimal value) {
+    List<Item> items = itemRepository.findBySafetyStockGreaterThan(value);
+    if (items.isEmpty()) {
+      throw new CustomException(ErrorCode.ITEM_NOT_FOUND);
+    }
+    return items;
+  }
+
+
 
   // 품목 코드 로직
   // REVIEW: 품목명 한글인 경우 어떻게 할 지?, 품목코드 명명 규칙 정해진게 있을까요?

--- a/smerp/src/main/java/com/domino/smerp/item/repository/ItemRepository.java
+++ b/smerp/src/main/java/com/domino/smerp/item/repository/ItemRepository.java
@@ -1,7 +1,12 @@
 package com.domino.smerp.item.repository;
 
 import com.domino.smerp.item.Item;
+import com.domino.smerp.item.ItemStatus;
+import com.domino.smerp.item.constants.ItemAct;
 import com.domino.smerp.item.repository.query.ItemQueryRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +17,18 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemQueryRepo
   boolean existsByName(final String name);
   boolean existsByRfid(final String rfid);
 
+  // 품목명 검색
+  Optional<Item> findByName(final String name);
+  // RFID 검색
+  Optional<Item> findByRfid(final String rfid);
+  // 품목구분 검색
+  List<Item> findByItemStatus(final ItemStatus itemStatus);
+  // 품목 사용상태
+  List<Item> findByItemAct(final ItemAct itemAct); //(ACTIVE("사용중"),INACTIVE("사용중지")
 
+  // 안전재고 수량
+  List<Item> findBySafetyStockLessThan(final BigDecimal value);   // 안전재고 미만인 품목들
+  List<Item> findBySafetyStockGreaterThan(final BigDecimal value); // 안전재고 이상인 품목들
 
 
   // TODO: 품목코드


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
- 다른 서비스에서 재사용할 수 있도록 `ItemRepository`에 공통 조회 메소드 추가
  - `List<Item> findItemByStatus(final ItemStatus itemStatus);` // 품목 구분별 조회
  - `Item findItemByName(final String name);` // 품목명으로 단일 조회
  - `Item findItemByRfid(final String rfid);` // RFID로 단일 조회
  - `List<Item> findItemByItemAct(final ItemAct itemAct);` // 품목 사용 상태별 조회
  - `List<Item> findItemsBySafetyStockLessThan(final BigDecimal value);` // 안전재고 미만
  - `List<Item> findItemsBySafetyStockGreaterThan(final BigDecimal value);` // 안전재고 이상

## ✨ 변경 사항 (Changes)
- [X] `ItemRepository`에 공통 `findBy` 메소드 추가
- [X] 서비스 레이어에서 해당 메소드 참조 가능하도록 인터페이스 정리
- [ ] 버그 수정 없음
- [ ] 기타 변경 없음

## 🔀 작업한 브랜치 (Working Branch)
- develop

## #️⃣ 관련 이슈 (Issue)
- Closes [#64](https://github.com/beyond-sw-camp/be18-2nd-Domino-SMERP/issues/64)

## ℹ️ 추가 설명 (Additional Info)
- 조회 조건은 대부분 단순 매핑이라 복잡한 로직은 없음
- 다른 서비스에서도 바로 사용할 수 있도록 `Entity` 반환 타입 유지
- 안전재고 비교 시 `BigDecimal` 타입으로 구현하여 재고 수량 확장성 고려

## 🔍 코드 리뷰 포인트 (Review Focus)
- 반환 타입을 `Entity`로 두는 게 맞을지, `DTO` 변환 레이어에서 처리하는 게 맞을지
- `ItemStatus` / `ItemAct` 같은 Enum 기반 검색 방식에 대한 네이밍/표현 적절성
- 추후 `Optional<Item>`으로 바꾸는 것이 더 안전할지 검토 필요

## 📸 스크린샷 (선택)
- 해당 없음
